### PR TITLE
Fix: invisible text on claim tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lido for Polygon
+# Lido on Polygon
 
 Lido Frontend Template is a project template for developing Lido applications. It features the standard Lido frontend stack including Next.js, SWR, ethers, Lido UI and styled-components. The purpose of this template is to standardize Lido frontends and to enable developers to start working on the application as soon as possible with minimal setup required.
 

--- a/components/claimCard/claimStyles.tsx
+++ b/components/claimCard/claimStyles.tsx
@@ -22,13 +22,15 @@ export const ClaimStatBalanceStyle = styled.div`
   font-size: ${({ theme }) => theme.fontSizesMap.xxs}px;
   line-height: 1.6em;
   width: 50%;
-
   :last-child {
     margin-right: 0;
   }
+  
 `;
 
-export const ClaimCardTitleStyle = styled.div``;
+export const ClaimCardTitleStyle = styled.div`
+  color: #7a8aa0;
+`;
 
 export const ClaimStatValueStyle = styled.div<{
   $small: boolean;

--- a/components/unstake/unstake.tsx
+++ b/components/unstake/unstake.tsx
@@ -414,7 +414,7 @@ const Unstake: FC<{ changeTab: (tab: string) => void }> = ({ changeTab }) => {
           {reward} {symbol}
         </DataTableRow>
         <DataTableRow title="Exchange rate">
-          1 {stSymbol} = {rate} {symbol}
+          1 {symbol} = {rate} {stSymbol}
         </DataTableRow>
       </DataTable>
       <StatusModal

--- a/components/wallet/wallet.tsx
+++ b/components/wallet/wallet.tsx
@@ -4,7 +4,7 @@ import {
   WalletCardRow,
   WalletCardAccount,
 } from 'components/walletCard';
-import { Divider } from '@lidofinance/lido-ui';
+import { Divider, Text } from '@lidofinance/lido-ui';
 import { useContractSWR, useSDK } from '@lido-sdk/react';
 import { useWeb3 } from '@lido-sdk/web3-react';
 import FormatToken from 'components/formatToken';
@@ -17,6 +17,7 @@ import {
   useMaticTokenWeb3,
 } from 'hooks';
 import { useState, useEffect } from 'react';
+import { BigNumber } from 'ethers';
 
 const Wallet: WalletComponent = (props) => {
   const { account } = useSDK();
@@ -75,22 +76,32 @@ const Wallet: WalletComponent = (props) => {
               />
             </>
           }
+          extra={
+            <>
+              <FormatToken
+                // TODO : replace hardcoded amount value
+                amount={BigNumber.from(20)}
+                symbol={"Matic"}
+                approx
+              />
+            </>
+          }
         />
-        {/* 
-        TODO: Add after historical data can be fetched
-        
+
+        {/* TODO: Add after historical data can be fetched */}
         <WalletCardBalance
           small
           title="Lido APR"
           loading={maticBalance.initialLoading}
           value={
             <>
+              {/* // TODO : replace hardcoded percentage value */}
               <Text style={{ color: '#53BA95' }} size="xs">
-                40%
+                40.5%
               </Text>
             </>
           }
-        /> */}
+        />
       </WalletCardRow>
     </WalletCard>
   );

--- a/components/wallet/wallet.tsx
+++ b/components/wallet/wallet.tsx
@@ -17,6 +17,8 @@ import {
   useMaticTokenWeb3,
 } from 'hooks';
 import { useState, useEffect } from 'react';
+
+//? temporary import
 import { BigNumber } from 'ethers';
 
 const Wallet: WalletComponent = (props) => {
@@ -31,6 +33,7 @@ const Wallet: WalletComponent = (props) => {
     method: 'balanceOf',
     params: [account],
   });
+  const [apr, setApr] = useState();
   const [maticSymbol, setMaticSymbol] = useState('MATIC');
   const [stMaticSymbol, setStMaticSymbol] = useState('stMATIC');
   useEffect(() => {
@@ -45,6 +48,15 @@ const Wallet: WalletComponent = (props) => {
       });
     }
   }, [maticTokenWeb3, stMaticTokenWeb3]);
+
+  useEffect(() => {
+    fetch('api/stats')
+      .then((res) => res.json())
+      .then((data) => {
+        setApr(data.apr);
+      });
+  }, []);
+
   const stMaticBalance = useContractSWR({
     contract: stMaticTokenRPC,
     method: 'balanceOf',
@@ -79,25 +91,22 @@ const Wallet: WalletComponent = (props) => {
           extra={
             <>
               <FormatToken
-                // TODO : replace hardcoded amount value
-                amount={BigNumber.from(20)}
-                symbol={"Matic"}
+                amount={BigNumber.from(20)} // TODO : replace hardcoded amount value
+                symbol={maticSymbol}
                 approx
               />
             </>
           }
         />
 
-        {/* TODO: Add after historical data can be fetched */}
         <WalletCardBalance
           small
           title="Lido APR"
           loading={maticBalance.initialLoading}
           value={
             <>
-              {/* // TODO : replace hardcoded percentage value */}
               <Text style={{ color: '#53BA95' }} size="xs">
-                40.5%
+                {apr === undefined ? 'Loading' : apr + '%'}
               </Text>
             </>
           }

--- a/faq/how-does-it-work.md
+++ b/faq/how-does-it-work.md
@@ -1,7 +1,7 @@
 ---
-title: How does Lido for Polygon work?
+title: How does Lido on Polygon work?
 ---
 
 
-When staking with Lido for Polygon, users receive stMATIC tokens as soon as they submit MATIC. Lido will calculate the current stMATIC/MATIC ratio and send the correct amount to the user.
-MATIC tokens are then delegated across Polygon validators that are part of Lido for Polygon.
+When staking with Lido on Polygon, users receive stMATIC tokens as soon as they submit MATIC. Lido will calculate the current stMATIC/MATIC ratio and send the correct amount to the user.
+MATIC tokens are then delegated across Polygon validators that are part of Lido on Polygon.

--- a/faq/lido-polygon.md
+++ b/faq/lido-polygon.md
@@ -1,10 +1,10 @@
 ---
-title: 'What is Lido for Polygon?'
+title: 'What is Lido on Polygon?'
 ---
 
 
-Lido for Polygon is a liquid staking solution for MATIC backed by industry-leading staking providers. Lido lets users earn MATIC staking rewards without needing to maintain infrastructure and enables them to trade staked positions, as well as participate in on-chain decentralized finance with their staked assets.
-Lido for Polygon gives you:
+Lido on Polygon is a liquid staking solution for MATIC backed by industry-leading staking providers. Lido lets users earn MATIC staking rewards without needing to maintain infrastructure and enables them to trade staked positions, as well as participate in on-chain decentralized finance with their staked assets.
+Lido on Polygon gives you:
 * Stake their MATIC tokens in a decentralized and secure way
 * Use their stMATIC on the secondary market
 * Do all of the above simply and easily with a click of a button on the UI

--- a/pages/api/stats.ts
+++ b/pages/api/stats.ts
@@ -28,15 +28,11 @@ export default async function handler(
 
   const contract = new Contract(lidoMaticAddress, ILidoMatic.abi, provider);
 
-  //? temporary default value is used to avoid errors
-  // TODO : handle errors
-  const {
-    price: { rate } = { rate: 1 },
-  } = await fetch(
+  const { price: { rate } = { rate: 1.6 } } = await fetch(
     `${ethplorerMainnetUrl}getTokenInfo/${maticAddress}?apiKey=${process.env.ETHPLORER_MAINNET_API_KEY}`,
   ).then((res) => res.json());
 
-  const { holdersCount } = await fetch(
+  const { holdersCount = 100 } = await fetch(
     `${ethplorerMainnetUrl}getTokenInfo/${lidoMaticAddress}?apiKey=${process.env.ETHPLORER_MAINNET_API_KEY}`,
   ).then((res) => res.json());
 

--- a/pages/api/stats.ts
+++ b/pages/api/stats.ts
@@ -28,8 +28,10 @@ export default async function handler(
 
   const contract = new Contract(lidoMaticAddress, ILidoMatic.abi, provider);
 
+  //? temporary default value is used to avoid errors
+  // TODO : handle errors
   const {
-    price: { rate },
+    price: { rate } = { rate: 1 },
   } = await fetch(
     `${ethplorerMainnetUrl}getTokenInfo/${maticAddress}?apiKey=${process.env.ETHPLORER_MAINNET_API_KEY}`,
   ).then((res) => res.json());

--- a/pages/api/stats.ts
+++ b/pages/api/stats.ts
@@ -52,6 +52,7 @@ export default async function handler(
     price: rate,
     apr: 8.676,
     stakers: holdersCount,
+    stMaticMarketCap: totalStMaticSupply,
     totalStaked: {
       token: formattedPooledMatic,
       usd: formattedPooledMatic * rate,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,19 +15,20 @@ import Claim from 'components/claim';
 import { formatBalance } from 'utils';
 import { SCANNERS, LIDO_MATIC_BY_NETWORK } from 'config';
 
+import { getHoldersCount, getTotalStMaticSupply } from "../utilsAPI";
+
 interface HomeProps {
   faqList: FAQItem[];
+  totalStMaticSupply?: number;
+  stakers?: number;
 }
 
-const Home: FC<HomeProps> = ({ faqList }) => {
+const Home: FC<HomeProps> = ({ faqList, totalStMaticSupply, stakers }) => {
   const { chainId } = useSDK();
   const maticTokenWeb3 = useMaticTokenWeb3();
   const lidoMaticRPC = useLidoMaticRPC();
   const [selectedTab, setSelectedTab] = useState('STAKE');
   const [symbol, setSymbol] = useState('MATIC');
-
-  const [stakers, setStakers] = useState();
-  const [totalstMatic, setTotalstMatic] = useState();
 
   maticTokenWeb3?.symbol().then(setSymbol);
 
@@ -35,16 +36,6 @@ const Home: FC<HomeProps> = ({ faqList }) => {
     contract: lidoMaticRPC,
     method: 'getTotalPooledMatic',
   });
-
-  useEffect(() => {
-    fetch('/api/stats')
-      .then((res) => res.json())
-      .then((data) => {
-        console.log(data);
-        setStakers(data.stakers);
-        setTotalstMatic(data.stMaticMarketCap);
-      });
-  }, []);
 
   return (
     <Layout
@@ -96,7 +87,7 @@ const Home: FC<HomeProps> = ({ faqList }) => {
               title="stMATIC market cap"
               // loading={tokenName.initialLoading}
             >
-              { totalstMatic ? `$ ${totalstMatic}` : "Loading"}
+              { totalStMaticSupply ? `$ ${totalStMaticSupply}` : "Loading"}
             </DataTableRow>
           </DataTable>
         </Block>
@@ -109,6 +100,11 @@ const Home: FC<HomeProps> = ({ faqList }) => {
 export default Home;
 
 export const getServerSideProps: GetServerSideProps<HomeProps> = async () => {
+
+  // stats values
+  const totalStMaticSupply = await getTotalStMaticSupply();
+  // const stakers = await getHoldersCount();
+
   // list of .md files from /faq/
   const fileList = [
     'lido-polygon',
@@ -121,5 +117,5 @@ export const getServerSideProps: GetServerSideProps<HomeProps> = async () => {
   ];
   const faqList = await getFaqList(fileList);
 
-  return { props: { faqList } };
+  return { props: { faqList, totalStMaticSupply } };
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -103,7 +103,7 @@ export const getServerSideProps: GetServerSideProps<HomeProps> = async () => {
 
   // stats values
   const totalStMaticSupply = await getTotalStMaticSupply();
-  // const stakers = await getHoldersCount();
+  const stakers = await getHoldersCount();
 
   // list of .md files from /faq/
   const fileList = [
@@ -117,5 +117,5 @@ export const getServerSideProps: GetServerSideProps<HomeProps> = async () => {
   ];
   const faqList = await getFaqList(fileList);
 
-  return { props: { faqList, totalStMaticSupply } };
+  return { props: { faqList, totalStMaticSupply, stakers } };
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { GetServerSideProps } from 'next';
 import { Block, Link, DataTable, DataTableRow } from '@lidofinance/lido-ui';
 import Tabs from 'components/tabs';
@@ -26,12 +26,25 @@ const Home: FC<HomeProps> = ({ faqList }) => {
   const [selectedTab, setSelectedTab] = useState('STAKE');
   const [symbol, setSymbol] = useState('MATIC');
 
+  const [stakers, setStakers] = useState();
+  const [totalstMatic, setTotalstMatic] = useState();
+
   maticTokenWeb3?.symbol().then(setSymbol);
 
   const totalTokenStaked = useContractSWR({
     contract: lidoMaticRPC,
     method: 'getTotalPooledMatic',
   });
+
+  useEffect(() => {
+    fetch('/api/stats')
+      .then((res) => res.json())
+      .then((data) => {
+        console.log(data);
+        setStakers(data.stakers);
+        setTotalstMatic(data.stMaticMarketCap);
+      });
+  }, []);
 
   return (
     <Layout
@@ -71,18 +84,20 @@ const Home: FC<HomeProps> = ({ faqList }) => {
             >
               {formatBalance(totalTokenStaked.data)} {symbol}
             </DataTableRow>
-            {/* 
-             TODO: uncomment after getting api key for etherscan
-            <DataTableRow title="Stakers" loading={tokenName.initialLoading}>
-              99 999
-            </DataTableRow>
-             */}
-            {/* <DataTableRow
-              title="stMATIC market cap"
-              loading={tokenName.initialLoading}
+
+            <DataTableRow
+              title="Stakers"
+              // loading={tokenName.initialLoading}
             >
-              $9,999,999,999
-            </DataTableRow> */}
+              { stakers ? stakers : "Loading" }
+            </DataTableRow>
+
+            <DataTableRow
+              title="stMATIC market cap"
+              // loading={tokenName.initialLoading}
+            >
+              { totalstMatic ? `$ ${totalstMatic}` : "Loading"}
+            </DataTableRow>
           </DataTable>
         </Block>
       </Section>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -39,7 +39,7 @@ const Home: FC<HomeProps> = ({ faqList, totalStMaticSupply, stakers }) => {
 
   return (
     <Layout
-      title="Lido for Polygon"
+      title="Lido on Polygon"
       subtitle="Stake Matic and receive stMatic while staking."
     >
       <Tabs

--- a/utilsAPI/index.ts
+++ b/utilsAPI/index.ts
@@ -1,2 +1,3 @@
 export * from './serverLogger';
 export * from './withCsp';
+export * from './stats';

--- a/utilsAPI/stats.ts
+++ b/utilsAPI/stats.ts
@@ -21,7 +21,7 @@ export const getApr = async (): Promise<number> => {
 }
 
 export const getRate = async () => {
-  const { price: { rate } = { rate: 1 } } = await fetch(
+  const { price: { rate } = { rate: 1.6 } } = await fetch(
     `${ethplorerMainnetUrl}getTokenInfo/${maticAddress}?apiKey=${process.env.ETHPLORER_MAINNET_API_KEY}`,
   ).then((res) => res.json());
 
@@ -29,7 +29,7 @@ export const getRate = async () => {
 };
 
 export const getHoldersCount = async () => {
-  const { holdersCount } = await fetch(
+  const { holdersCount = 100 } = await fetch(
     `${ethplorerMainnetUrl}getTokenInfo/${lidoMaticAddress}?apiKey=${process.env.ETHPLORER_MAINNET_API_KEY}`,
   ).then((res) => res.json());
 

--- a/utilsAPI/stats.ts
+++ b/utilsAPI/stats.ts
@@ -1,0 +1,63 @@
+import { getInfuraRPCUrl } from '@lido-sdk/fetch';
+import { BigNumber, Contract, providers, utils } from 'ethers';
+
+import { getLidoMaticAddress, getMaticAddress } from 'config';
+
+import getConfig from 'next/config';
+
+import ILidoMatic from '../abi/StMATIC.json';
+import { formatBalance } from 'utils';
+
+const { publicRuntimeConfig, serverRuntimeConfig } = getConfig();
+
+const { ethplorerMainnetUrl, defaultChain } = publicRuntimeConfig;
+const { infuraApiKey } = serverRuntimeConfig;
+const lidoMaticAddress = getLidoMaticAddress(+defaultChain);
+const maticAddress = getMaticAddress(+defaultChain);
+
+export const getApr = async (): Promise<number> => {
+  const apr = 18;
+  return new Promise(resolve => setTimeout(() => resolve(apr), 100))
+}
+
+export const getRate = async () => {
+  const { price: { rate } = { rate: 1 } } = await fetch(
+    `${ethplorerMainnetUrl}getTokenInfo/${maticAddress}?apiKey=${process.env.ETHPLORER_MAINNET_API_KEY}`,
+  ).then((res) => res.json());
+
+  return rate;
+};
+
+export const getHoldersCount = async () => {
+  const { holdersCount } = await fetch(
+    `${ethplorerMainnetUrl}getTokenInfo/${lidoMaticAddress}?apiKey=${process.env.ETHPLORER_MAINNET_API_KEY}`,
+  ).then((res) => res.json());
+
+  return holdersCount;
+};
+
+export const getTotalPooledMatic = async () => {
+  const provider = new providers.JsonRpcProvider({
+    url: getInfuraRPCUrl(+defaultChain, infuraApiKey),
+  });
+
+  const contract = new Contract(lidoMaticAddress, ILidoMatic.abi, provider);
+
+  const totalPooledMatic = await contract.getTotalPooledMatic();
+
+  return (+utils.formatEther(totalPooledMatic));
+};
+
+export const getTotalStMaticSupply = async () => {
+  const provider = new providers.JsonRpcProvider({
+    url: getInfuraRPCUrl(+defaultChain, infuraApiKey),
+  });
+
+  const contract = new Contract(lidoMaticAddress, ILidoMatic.abi, provider);
+
+  const totalStMaticSupply = await contract
+    .totalSupply()
+    .then((res: BigNumber) => formatBalance(res));
+
+  return totalStMaticSupply;
+};

--- a/websiteConfig.json
+++ b/websiteConfig.json
@@ -1,5 +1,5 @@
 {
   "title": "Stake | Lido",
-  "description": "Lido for Polygon is a liquid staking solution for MATIC backed by industry-leading staking providers. Lido lets users earn MATIC staking rewards without needing to maintain infrastructure and enables them to trade staked positions, as well as participate in on-chain decentralized finance with their staked assets.",
+  "description": "Lido on Polygon is a liquid staking solution for MATIC backed by industry-leading staking providers. Lido lets users earn MATIC staking rewards without needing to maintain infrastructure and enables them to trade staked positions, as well as participate in on-chain decentralized finance with their staked assets.",
   "appName": "Stake MATIC | Lido"
 }


### PR DESCRIPTION
This PR fixes the issue on the claim tab:

**Description:**
When toggling the dark theme on the claim tab the title text is colored white on a white background which makes it invisible
![image](https://user-images.githubusercontent.com/102021206/159899316-7b03b4dc-55df-4123-9042-7057b53c73d1.png)

**Approach**
Override the color property on the title text component style to stay grey instead of inheriting its color from the theme provider