### PR TITLE
Fix/add stats

### DIFF
--- a/components/wallet/wallet.tsx
+++ b/components/wallet/wallet.tsx
@@ -36,6 +36,16 @@ const Wallet: WalletComponent = (props) => {
   const [maticEquiv, setMaticEquiv] = useState<BigNumber>();
   const [maticSymbol, setMaticSymbol] = useState('MATIC');
   const [stMaticSymbol, setStMaticSymbol] = useState('stMATIC');
+  const [apr, setApr] = useState();
+
+  useEffect(() => {
+    fetch('api/stats')
+      .then((res) => res.json())
+      .then((data) => {
+        setApr(data.apr);
+      });
+  }, []);
+
   useEffect(() => {
     if (maticTokenWeb3) {
       maticTokenWeb3.symbol().then((res) => {
@@ -96,11 +106,11 @@ const Wallet: WalletComponent = (props) => {
         <WalletCardBalance
           small
           title="Lido APR"
-          loading={maticBalance.initialLoading}
+          loading={!apr}
           value={
             <>
               <Text style={{ color: '#53BA95' }} size="xs">
-                8.676% {/* TODO: replace hardcoded value */}
+                {`${apr}%`}
               </Text>
             </>
           }

--- a/components/wallet/wallet.tsx
+++ b/components/wallet/wallet.tsx
@@ -8,6 +8,8 @@ import { Divider, Text } from '@lidofinance/lido-ui';
 import { useContractSWR, useSDK } from '@lido-sdk/react';
 import { useWeb3 } from '@lido-sdk/web3-react';
 import FormatToken from 'components/formatToken';
+import { utils, BigNumber } from 'ethers';
+import { formatBalance } from 'utils';
 import FallbackWallet from 'components/fallbackWallet';
 import { WalletComponent } from './types';
 import {
@@ -30,6 +32,8 @@ const Wallet: WalletComponent = (props) => {
     method: 'balanceOf',
     params: [account],
   });
+
+  const [maticEquiv, setMaticEquiv] = useState<BigNumber>();
   const [maticSymbol, setMaticSymbol] = useState('MATIC');
   const [stMaticSymbol, setStMaticSymbol] = useState('stMATIC');
   useEffect(() => {
@@ -41,6 +45,14 @@ const Wallet: WalletComponent = (props) => {
     if (stMaticTokenWeb3) {
       stMaticTokenWeb3.symbol().then((res) => {
         setStMaticSymbol(res);
+      });
+
+      const amount = utils.parseUnits(
+        formatBalance(maticBalance.data),
+        'ether',
+      );
+      stMaticTokenWeb3.convertStMaticToMatic(amount).then(([res]) => {
+        setMaticEquiv(res);
       });
     }
   }, [maticTokenWeb3, stMaticTokenWeb3]);
@@ -77,11 +89,7 @@ const Wallet: WalletComponent = (props) => {
           }
           extra={
             <>
-              <FormatToken
-                amount={stMaticBalance.data} // TODO : replace with converted value from stMATIC to MATIC
-                symbol={maticSymbol}
-                approx
-              />
+              <FormatToken amount={maticEquiv} symbol={maticSymbol} approx />
             </>
           }
         />
@@ -92,7 +100,7 @@ const Wallet: WalletComponent = (props) => {
           value={
             <>
               <Text style={{ color: '#53BA95' }} size="xs">
-                40% {/* TODO: replace hardcoded value */}
+                8.676% {/* TODO: replace hardcoded value */}
               </Text>
             </>
           }

--- a/components/wallet/wallet.tsx
+++ b/components/wallet/wallet.tsx
@@ -4,7 +4,7 @@ import {
   WalletCardRow,
   WalletCardAccount,
 } from 'components/walletCard';
-import { Divider } from '@lidofinance/lido-ui';
+import { Divider, Text } from '@lidofinance/lido-ui';
 import { useContractSWR, useSDK } from '@lido-sdk/react';
 import { useWeb3 } from '@lido-sdk/web3-react';
 import FormatToken from 'components/formatToken';
@@ -75,10 +75,16 @@ const Wallet: WalletComponent = (props) => {
               />
             </>
           }
+          extra={
+            <>
+              <FormatToken
+                amount={stMaticBalance.data} // TODO : replace with converted value from stMATIC to MATIC
+                symbol={maticSymbol}
+                approx
+              />
+            </>
+          }
         />
-        {/* 
-        TODO: Add after historical data can be fetched
-        
         <WalletCardBalance
           small
           title="Lido APR"
@@ -86,11 +92,11 @@ const Wallet: WalletComponent = (props) => {
           value={
             <>
               <Text style={{ color: '#53BA95' }} size="xs">
-                40%
+                40% {/* TODO: replace hardcoded value */}
               </Text>
             </>
           }
-        /> */}
+        />
       </WalletCardRow>
     </WalletCard>
   );

--- a/components/wallet/wallet.tsx
+++ b/components/wallet/wallet.tsx
@@ -33,6 +33,12 @@ const Wallet: WalletComponent = (props) => {
     params: [account],
   });
 
+  const stMaticBalance = useContractSWR({
+    contract: stMaticTokenRPC,
+    method: 'balanceOf',
+    params: [account],
+  });
+
   const [maticEquiv, setMaticEquiv] = useState<BigNumber>();
   const [maticSymbol, setMaticSymbol] = useState('MATIC');
   const [stMaticSymbol, setStMaticSymbol] = useState('stMATIC');
@@ -58,19 +64,15 @@ const Wallet: WalletComponent = (props) => {
       });
 
       const amount = utils.parseUnits(
-        formatBalance(maticBalance.data),
+        formatBalance(stMaticBalance.data),
         'ether',
       );
       stMaticTokenWeb3.convertStMaticToMatic(amount).then(([res]) => {
         setMaticEquiv(res);
       });
     }
-  }, [maticTokenWeb3, stMaticTokenWeb3]);
-  const stMaticBalance = useContractSWR({
-    contract: stMaticTokenRPC,
-    method: 'balanceOf',
-    params: [account],
-  });
+  }, [maticTokenWeb3, stMaticTokenWeb3, stMaticBalance.data]);
+
   return (
     <WalletCard {...props}>
       <WalletCardRow>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,12 @@
-import { FC, useState } from 'react';
+import { FC, useState, useEffect } from 'react';
 import { GetServerSideProps } from 'next';
-import { Block, Link, DataTable, DataTableRow } from '@lidofinance/lido-ui';
+import {
+  Block,
+  Link,
+  DataTable,
+  DataTableRow,
+  Text,
+} from '@lidofinance/lido-ui';
 import Tabs from 'components/tabs';
 import Wallet from 'components/wallet';
 import Section from 'components/section';
@@ -26,12 +32,26 @@ const Home: FC<HomeProps> = ({ faqList }) => {
   const [selectedTab, setSelectedTab] = useState('STAKE');
   const [symbol, setSymbol] = useState('MATIC');
 
+  const [stakers, setStakers] = useState();
+  const [apr, setApr] = useState();
+  const [marketCap, setMarketCap] = useState();
+
   maticTokenWeb3?.symbol().then(setSymbol);
 
   const totalTokenStaked = useContractSWR({
     contract: lidoMaticRPC,
     method: 'getTotalPooledMatic',
   });
+
+  useEffect(() => {
+    fetch('api/stats')
+      .then((res) => res.json())
+      .then((data) => {
+        setStakers(data.stakers);
+        setApr(data.apr);
+        setMarketCap(data.totalStaked.usd);
+      });
+  }, []);
 
   return (
     <Layout
@@ -61,8 +81,10 @@ const Home: FC<HomeProps> = ({ faqList }) => {
       >
         <Block>
           <DataTable title="Lido">
-            <DataTableRow title="Annual percentage rate">
-              40.5% {/* TODO: replace hardcoded value */}
+            <DataTableRow title="Annual percentage rate" loading={!apr}>
+              <Text style={{ color: '#53BA95' }} size="xs">
+                {`${apr}%`}
+              </Text>
             </DataTableRow>
             <DataTableRow
               title="Total staked with Lido"
@@ -71,18 +93,15 @@ const Home: FC<HomeProps> = ({ faqList }) => {
               {formatBalance(totalTokenStaked.data)} {symbol}
             </DataTableRow>
 
-            <DataTableRow
-              title="Stakers"
-              // loading={tokenName.initialLoading}
-            >
-              99 999 {/* TODO: replace hardcoded value */}
+            <DataTableRow title="Stakers" loading={!stakers}>
+              {stakers}
             </DataTableRow>
 
             <DataTableRow
               title="stMATIC market cap"
-              // loading={tokenName.initialLoading}
+              loading={!marketCap}
             >
-              $9,999,999,999 {/* TODO: replace hardcoded value */}
+              {`\$${marketCap}`}
             </DataTableRow>
           </DataTable>
         </Block>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -61,28 +61,29 @@ const Home: FC<HomeProps> = ({ faqList }) => {
       >
         <Block>
           <DataTable title="Lido">
-            {/*
-              TODO: Add after historical data can be fetched
-              <DataTableRow title="Annual percentage rate">40.5%</DataTableRow>
-             */}
+            <DataTableRow title="Annual percentage rate">
+              40.5% {/* TODO: replace hardcoded value */}
+            </DataTableRow>
             <DataTableRow
               title="Total staked with Lido"
               loading={totalTokenStaked.initialLoading}
             >
               {formatBalance(totalTokenStaked.data)} {symbol}
             </DataTableRow>
-            {/* 
-             TODO: uncomment after getting api key for etherscan
-            <DataTableRow title="Stakers" loading={tokenName.initialLoading}>
-              99 999
-            </DataTableRow>
-             */}
-            {/* <DataTableRow
-              title="stMATIC market cap"
-              loading={tokenName.initialLoading}
+
+            <DataTableRow
+              title="Stakers"
+              // loading={tokenName.initialLoading}
             >
-              $9,999,999,999
-            </DataTableRow> */}
+              99 999 {/* TODO: replace hardcoded value */}
+            </DataTableRow>
+
+            <DataTableRow
+              title="stMATIC market cap"
+              // loading={tokenName.initialLoading}
+            >
+              $9,999,999,999 {/* TODO: replace hardcoded value */}
+            </DataTableRow>
           </DataTable>
         </Block>
       </Section>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -97,11 +97,8 @@ const Home: FC<HomeProps> = ({ faqList }) => {
               {stakers}
             </DataTableRow>
 
-            <DataTableRow
-              title="stMATIC market cap"
-              loading={!marketCap}
-            >
-              {`\$${marketCap}`}
+            <DataTableRow title="stMATIC market cap" loading={!marketCap}>
+              {`$${marketCap}`}
             </DataTableRow>
           </DataTable>
         </Block>


### PR DESCRIPTION
## Description
This PR introduces new data outputs to the UI displaying real (fetched) data

## List of data outputs
- Staked stMATIC amount equivalent to MATIC
- **Lido APR** on the wallet component
- **Annual percentage rate** (APR) in statistics section
- **Stakers** in statistics section
- **stMATIC market cap**

## Data sources
- **StMATIC.sol** smart contract
  - Staked stMATIC amount equivalent to MATIC -> convertStMaticToMatic function (input: staked amount in stMATIC)
- **api/stats** endpoint
  - APR -> data.apr
  - Stakers -> data.stakers
  - stMATIC market cap -> data.totalStaked.usd !

![image](https://user-images.githubusercontent.com/102021206/161057456-9bfeee2c-6745-4d59-9b35-a892ce8fa9a2.png)
